### PR TITLE
[Fix] 가게 검색 API 수정

### DIFF
--- a/src/pages/searchstore/SearchStore.jsx
+++ b/src/pages/searchstore/SearchStore.jsx
@@ -25,7 +25,7 @@ export default function SearchStore() {
   const [keyword, setKeyword] = useState(''); // 검색어
   const [currentIndex, setCurrentIndex] = useState(0); // 카드 페이지네이션 인덱스
 
-  // 평점 옵션 (정확히 이 값들만 minRating으로 인정)
+  // 평점 옵션
   const ratingOptions = ['4.5', '4.0', '3.5'];
 
   // API 호출 (검색 결과)
@@ -47,7 +47,7 @@ export default function SearchStore() {
 
   const toilets = data?.data?.toilets || [];
 
-  // 단일 선택 그룹 관리용
+  // 단일 선택 그룹
   const SINGLE_KIND = ['공공', '민간'];
   const SINGLE_RATING = ['4.5', '4.0', '3.5'];
 
@@ -71,7 +71,7 @@ export default function SearchStore() {
     기저귀교환대: { key: 'special', mode: 'multi' },
   };
 
-  const clearAll = () => setSelected([]); // 전체 해제
+  const clearAll = () => setSelected([]);
   const removeOne = (label) =>
     setSelected((prev) => prev.filter((x) => x !== label));
 
@@ -182,8 +182,8 @@ export default function SearchStore() {
               </p>
             )}
 
-            {/* 카드 컨테이너 */}
             <div className="w-[1193px] flex items-center gap-6 mb-[229px]">
+              {/* 이전 화살표 */}
               <button
                 type="button"
                 aria-label="이전 목록"
@@ -194,6 +194,7 @@ export default function SearchStore() {
                 <ArrowLeft className="w-6 h-6" />
               </button>
 
+              {/* 카드 */}
               {toilets.slice(currentIndex, currentIndex + 4).map((t) => (
                 <div
                   key={t.toiletId}
@@ -203,7 +204,18 @@ export default function SearchStore() {
                     className="relative rounded-[10px] overflow-hidden"
                     style={{ width: '256px', height: '256px' }}
                   >
-                    <NearbyToilet className="w-full h-full object-cover" />
+                    {/* 이미지 있으면 표시, 없으면 아이콘 fallback */}
+                    {t.mainImageUrl ? (
+                      <img
+                        src={t.mainImageUrl}
+                        alt={t.name}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <NearbyToilet className="w-full h-full object-cover" />
+                    )}
+
+                    {/* 공공/민간 뱃지 */}
                     <span
                       className={[
                         'absolute right-3 bottom-3 h-7 px-3 rounded-full',
@@ -215,7 +227,7 @@ export default function SearchStore() {
                     </span>
                   </div>
 
-                  {/* 가게명 + 평점 */}
+                  {/* 이름 + 평점 + 태그 */}
                   <div className="mt-4">
                     <div className="flex items-start justify-between">
                       <p
@@ -236,7 +248,6 @@ export default function SearchStore() {
                       </div>
                     </div>
 
-                    {/* 태그 칩 */}
                     <div className="grid grid-cols-2 gap-2 mt-4">
                       {t.tags?.map((tag, i) => (
                         <span
@@ -254,6 +265,7 @@ export default function SearchStore() {
                 </div>
               ))}
 
+              {/* 다음 화살표 */}
               <button
                 type="button"
                 aria-label="다음 목록"


### PR DESCRIPTION
### 💡 To Reviewers

가게 검색 페이지 수정

---

### 🔥 작업 내용

SearchStore.jsx :

가게 검색 페이지 전체 UI 및 기능 구현
SearchBar와 Filter 컴포넌트 연결
선택된 칩(필터) 관리 (추가/삭제/전체 해제)
TanStack Query(useSearchResults)로 API 연동 (검색어, 평점, 유형, 태그 필터링)
카드 목록 슬라이드 기능 (좌/우 화살표로 4개 단위 넘기기)
카드 UI (이미지, 가게명, 별점, 태그 칩 2열 배치)
버그 수정: 24시간이 minRating으로 잘못 들어가던 문제 해결 (정확히 평점 칩만 minRating으로 매핑)
필터 팝오버 위치 고정 (검색창/버튼 기준, 칩 영역 높이에 영향 안 받도록 수정)
SearchBar.jsx :

검색창 UI 및 자동완성 기능 구현
/api/search/auto API 연동 (입력값 기반 자동완성)
선택된 검색어 전달 → SearchStore에서 검색 실행
디자인 유지하면서 API 연결
Filter.jsx :

필터 박스 UI 구성 (공공/민간, 최소 평점, 기본 시설, 상태, 특수 시설)
storeApi.js (hooks/store/useStoreApi.js 내부) :
/api/search/results API 호출 훅 정의
keyword, minRating, type, tags 쿼리 파라미터 전달
apis>store>storeApi.js
hooks>store>useStoreApi.js

** 화장실 카드 이미지 처리 로직 추가 (mainImageUrl 우선, 없으면 아이콘 표시) **

---

### 🤔 추후 작업 예정

- 이후 계획 중이거나 추가 구현이 필요한 내용을 적어주세요.

---

### 📸 작업 결과 (선택)

- 작업 결과를 보여주는 스크린샷이 있다면 첨부해주세요.

---

### 🔗 관련 이슈 (선택)

- 연결된 이슈 번호가 있다면 '#번호' 형식으로 작성해주세요.
