### PR TITLE
[Feat] 마이페이지 - 등록한 화장실 관리 API 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,35 +19,47 @@ import ReviewManagement from '@/pages/mypage/ReviewManagement';
 import ToiletManagement from '@/pages/mypage/ToiletManagement';
 import ProfileManagement from '@/pages/mypage/ProfileManagement';
 
+import EditToilet from '@/pages/mypage/EditToilet';
+
 function App() {
   return (
     <BrowserRouter>
       <Navbar />
       <Routes>
+        {/* 홈 */}
         <Route path="/" element={<Home />} />
+
+        {/* 검색 관련 */}
         <Route path="/search-store" element={<SearchStore />} />
         <Route path="/find-toilet" element={<SearchToilet />} />
         <Route path="/find-toilet/urgent" element={<SearchToiletUrgent />} />
+
+        {/* 화장실 등록 */}
         <Route path="/register-toilet" element={<RegisterToilet />} />
+
+        {/* AI 챗봇 */}
         <Route path="/ai-chatbot" element={<AiChatbot />} />
+
+        {/* 화장실 상세/리뷰 */}
         <Route path="/toilet-detail/:id" element={<ToiletDetailPage />} />
         <Route path="/review-toilet/:id" element={<ReviewToilet />} />
         <Route path="/review-toilet" element={<ReviewToiletList />} />
 
-        {/* 로그인 관련 라우트 */}
+        {/* 로그인 관련 */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/oauth/kakao/callback" element={<KakaoCallback />} />
         <Route path="/oauth2/code/google" element={<GoogleCallback />} />
 
         {/* MyPage 중첩 라우팅 */}
         <Route path="/mypage" element={<MyPage />}>
-          {/* /mypage 들어왔을 때 기본적으로 profile로 이동 */}
           <Route index element={<Navigate to="profile" replace />} />
-
           <Route path="reviews" element={<ReviewManagement />} />
           <Route path="profile" element={<ProfileManagement />} />
           <Route path="toilets" element={<ToiletManagement />} />
         </Route>
+
+        {/* EditToilet 페이지 */}
+        <Route path="/edit-toilet/:toiletId" element={<EditToilet />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/apis/mypage/toiletApi.js
+++ b/src/apis/mypage/toiletApi.js
@@ -1,0 +1,7 @@
+import axiosInstance from '@/apis/instance';
+
+// 내가 등록한 화장실 목록 조회
+export const getMyToilets = async () => {
+  const response = await axiosInstance.get('/api/users/me/toilets');
+  return response.data;
+};

--- a/src/apis/mypage/toiletApi.js
+++ b/src/apis/mypage/toiletApi.js
@@ -2,6 +2,61 @@ import axiosInstance from '@/apis/instance';
 
 // 내가 등록한 화장실 목록 조회
 export const getMyToilets = async () => {
-  const response = await axiosInstance.get('/api/users/me/toilets');
-  return response.data;
+  const res = await axiosInstance.get('/api/users/me/toilets');
+  return res.data;
+};
+
+// 화장실 상세 조회
+export const getToiletById = async (id) => {
+  const res = await axiosInstance.get(`/api/toilets/${id}`);
+  return res.data;
+};
+
+// 화장실 등록
+export const createToilet = async (toiletData) => {
+  const res = await axiosInstance.post('/api/toilets', toiletData);
+  return res.data;
+};
+
+// 화장실 수정 (기존)
+export const updateToilet = async ({ id, toiletData }) => {
+  const res = await axiosInstance.put(`/api/toilets/${id}`, toiletData);
+  return res.data;
+};
+
+// 이미지 업로드 (multipart/form-data, body에 toiletId 포함)
+export const uploadToiletImages = async (toiletId, files) => {
+  const formData = new FormData();
+  formData.append('toiletId', toiletId);
+  Array.from(files).forEach((file) => {
+    formData.append('files', file);
+  });
+
+  const res = await axiosInstance.post('/api/toilets/images', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+};
+
+// 이미지 단건 삭제
+export const deleteToiletImage = async (toiletId, imageId) => {
+  const res = await axiosInstance.delete(
+    `/api/toilets/${toiletId}/images/${imageId}`
+  );
+  return res.data;
+};
+
+// 이미지 전체 삭제
+export const deleteAllToiletImages = async (toiletId) => {
+  const res = await axiosInstance.delete(`/api/toilets/${toiletId}/images`);
+  return res.data;
+};
+
+// 화장실 수정
+export const updateToiletWithImages = async ({ id, toiletData, imageIds }) => {
+  const res = await axiosInstance.put(`/api/toilets/${id}`, {
+    ...toiletData,
+    imageIds, // 서버에서 남길 이미지 ID 배열
+  });
+  return res.data;
 };

--- a/src/apis/mypage/toiletApi.js
+++ b/src/apis/mypage/toiletApi.js
@@ -2,61 +2,52 @@ import axiosInstance from '@/apis/instance';
 
 // 내가 등록한 화장실 목록 조회
 export const getMyToilets = async () => {
-  const res = await axiosInstance.get('/api/users/me/toilets');
-  return res.data;
+  const response = await axiosInstance.get('/api/users/me/toilets');
+  return response.data;
 };
 
 // 화장실 상세 조회
 export const getToiletById = async (id) => {
-  const res = await axiosInstance.get(`/api/toilets/${id}`);
-  return res.data;
+  const response = await axiosInstance.get(`/api/toilets/${id}`);
+  return response.data;
 };
 
 // 화장실 등록
 export const createToilet = async (toiletData) => {
-  const res = await axiosInstance.post('/api/toilets', toiletData);
-  return res.data;
+  const response = await axiosInstance.post('/api/toilets', toiletData);
+  return response.data;
 };
 
-// 화장실 수정 (기존)
+// 화장실 수정 (기본 정보)
 export const updateToilet = async ({ id, toiletData }) => {
-  const res = await axiosInstance.put(`/api/toilets/${id}`, toiletData);
-  return res.data;
+  const response = await axiosInstance.put(`/api/toilets/${id}`, toiletData);
+  return response.data;
 };
 
-// 이미지 업로드 (multipart/form-data, body에 toiletId 포함)
-export const uploadToiletImages = async (toiletId, files) => {
-  const formData = new FormData();
-  formData.append('toiletId', toiletId);
-  Array.from(files).forEach((file) => {
-    formData.append('files', file);
-  });
-
-  const res = await axiosInstance.post('/api/toilets/images', formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-  return res.data;
+// 화장실 이미지 업로드
+export const uploadToiletImages = async (imageData) => {
+  const response = await axiosInstance.post(
+    `/api/toilets/images/upload`,
+    imageData,
+    {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    }
+  );
+  return response.data;
 };
 
-// 이미지 단건 삭제
-export const deleteToiletImage = async (toiletId, imageId) => {
-  const res = await axiosInstance.delete(
+// 화장실 이미지 단건 삭제
+export const deleteToiletImage = async ({ toiletId, imageId }) => {
+  const response = await axiosInstance.delete(
     `/api/toilets/${toiletId}/images/${imageId}`
   );
-  return res.data;
+  return response.data;
 };
 
-// 이미지 전체 삭제
-export const deleteAllToiletImages = async (toiletId) => {
-  const res = await axiosInstance.delete(`/api/toilets/${toiletId}/images`);
-  return res.data;
-};
-
-// 화장실 수정
-export const updateToiletWithImages = async ({ id, toiletData, imageIds }) => {
-  const res = await axiosInstance.put(`/api/toilets/${id}`, {
-    ...toiletData,
-    imageIds, // 서버에서 남길 이미지 ID 배열
-  });
-  return res.data;
+// 화장실 이미지 전체 삭제
+export const deleteAllToiletImages = async ({ toiletId }) => {
+  const response = await axiosInstance.delete(
+    `/api/toilets/${toiletId}/images`
+  );
+  return response.data;
 };

--- a/src/components/mypage/ToiletCard.jsx
+++ b/src/components/mypage/ToiletCard.jsx
@@ -1,59 +1,28 @@
-import { useState } from 'react';
 import ArrowIcon from '@/assets/svg/arrow.svg?react';
+import { useNavigate } from 'react-router-dom';
 
-const ToiletCard = ({ toilet, onSave }) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [name, setName] = useState(toilet.name);
-  const [address, setAddress] = useState(toilet.address);
-
-  const handleSaveClick = () => {
-    onSave(toilet.id, { name, address }); // 상위 업데이트
-    setIsEditing(false);
-  };
+const ToiletCard = ({ toilet }) => {
+  const navigate = useNavigate();
 
   return (
     <div className="flex justify-between items-start px-14 py-12 bg-white">
       {/* 왼쪽: 화장실 정보 */}
       <div>
-        {isEditing ? (
-          <div className="flex flex-col gap-2 mb-2">
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              className="px-3 py-2 border border-gray-3 rounded-md text-body2 text-gray-10 w-[300px]"
-            />
-            <input
-              type="text"
-              value={address}
-              onChange={(e) => setAddress(e.target.value)}
-              className="px-3 py-2 border border-gray-3 rounded-md text-body2 text-gray-10 w-[500px]"
-            />
-            <p className="text-body2 text-gray-5">등록일 {toilet.date}</p>
-          </div>
-        ) : (
-          <>
-            <div className="flex items-center gap-[16px] mb-2">
-              <h3 className="text-heading3-bold text-gray-10">{toilet.name}</h3>
-              <ArrowIcon className="w-4 h-4 text-gray-10" />
-            </div>
-            <p className="text-body1 text-gray-5 mb-1">{toilet.address}</p>
-            <p className="text-body2 text-gray-5">등록일 {toilet.date}</p>
-          </>
-        )}
+        <div className="flex items-center gap-[16px] mb-2">
+          <h3 className="text-heading3-bold text-gray-10">{toilet.name}</h3>
+          <ArrowIcon className="w-4 h-4 text-gray-10" />
+        </div>
+        <p className="text-body1 text-gray-5 mb-1">{toilet.address}</p>
+        <p className="text-body2 text-gray-5">등록일 {toilet.date}</p>
       </div>
 
-      {/* 오른쪽 버튼 (수정하기 ↔ 저장하기) */}
+      {/* 오른쪽 버튼 */}
       <button
-        onClick={isEditing ? handleSaveClick : () => setIsEditing(true)}
-        className={`px-6 py-2 rounded-[10px] border text-body2 flex items-center justify-center whitespace-nowrap
-          ${
-            isEditing
-              ? 'bg-main text-white border-main hover:bg-main-2'
-              : 'bg-gray-0 text-gray-4 border-gray-4 hover:bg-gray-1'
-          }`}
+        onClick={() => navigate(`/edit-toilet/${toilet.id}`)}
+        className="px-6 py-2 rounded-[10px] border text-body2 flex items-center justify-center whitespace-nowrap
+          bg-gray-0 text-gray-4 border-gray-4 hover:bg-gray-1"
       >
-        {isEditing ? '저장하기' : '수정하기'}
+        수정하기
       </button>
     </div>
   );

--- a/src/components/register/AddressForm.jsx
+++ b/src/components/register/AddressForm.jsx
@@ -1,6 +1,7 @@
 const AddressForm = ({ formData, onInputChange }) => {
   return (
     <div className="flex flex-col items-start gap-8 p-10 self-stretch rounded-[10px] border border-gray-2 bg-white">
+      {/* 주소 입력 */}
       <div className="flex flex-col gap-4 w-full">
         <div className="text-body1 text-gray-10">주소 등록</div>
         <input
@@ -12,13 +13,14 @@ const AddressForm = ({ formData, onInputChange }) => {
         />
       </div>
 
+      {/* 층수, 호수 입력 */}
       <div className="w-full">
-        <div className="text-body1 text-gray-8 mb-4">세부주소</div>
+        <div className="text-body1 text-gray-8 mb-4">층수</div>
         <input
           type="text"
-          value={formData.detailAddress}
-          onChange={(e) => onInputChange('detailAddress', e.target.value)}
-          placeholder="층수, 호수를 입력해주세요"
+          value={formData.floor ?? ''}
+          onChange={(e) => onInputChange('floor', e.target.value)}
+          placeholder="층수를 입력해주세요 (예: 1, B1)"
           className="w-full h-[54px] px-6 py-4 rounded-[10px] border border-gray-3 bg-white text-body2 placeholder-gray-4 outline-none focus:border-main transition-colors"
         />
       </div>

--- a/src/components/register/AddressForm.jsx
+++ b/src/components/register/AddressForm.jsx
@@ -13,13 +13,13 @@ const AddressForm = ({ formData, onInputChange }) => {
         />
       </div>
 
-      {/* 층수, 호수 입력 */}
+      {/* 층수 입력 */}
       <div className="w-full">
         <div className="text-body1 text-gray-8 mb-4">층수</div>
         <input
           type="text"
-          value={formData.floor ?? ''}
-          onChange={(e) => onInputChange('floor', e.target.value)}
+          value={formData.detailAddress ?? ''}
+          onChange={(e) => onInputChange('detailAddress', e.target.value)}
           placeholder="층수를 입력해주세요 (예: 1, B1)"
           className="w-full h-[54px] px-6 py-4 rounded-[10px] border border-gray-3 bg-white text-body2 placeholder-gray-4 outline-none focus:border-main transition-colors"
         />

--- a/src/hooks/mypage/useToiletApi.js
+++ b/src/hooks/mypage/useToiletApi.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyToilets } from '@/apis/mypage/toiletApi';
+
+export const useMyToilets = () => {
+  return useQuery({
+    queryKey: ['myToilets'],
+    queryFn: getMyToilets,
+    staleTime: 5 * 60 * 1000, // 5분
+    cacheTime: 10 * 60 * 1000, // 10분
+  });
+};

--- a/src/hooks/mypage/useToiletApi.js
+++ b/src/hooks/mypage/useToiletApi.js
@@ -39,12 +39,10 @@ export const useUpdateToilet = () => {
 };
 
 // 이미지 업로드
-export const useUploadToiletImages = () => {
+export const useUploadToiletImages = (options = {}) => {
   return useMutation({
     mutationFn: (imageData) => uploadToiletImages(imageData),
-    onSuccess: (data) => {
-      console.log('✅ 이미지 업로드 성공:', data);
-    },
+    ...options,
   });
 };
 

--- a/src/hooks/mypage/useToiletApi.js
+++ b/src/hooks/mypage/useToiletApi.js
@@ -1,50 +1,36 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
 import {
   getMyToilets,
   getToiletById,
-  createToilet,
   updateToilet,
   uploadToiletImages,
   deleteToiletImage,
   deleteAllToiletImages,
-  updateToiletWithImages,
 } from '@/apis/mypage/toiletApi';
 
-// 내가 등록한 화장실 목록 조회
+// 상세 조회
+export const useToiletDetail = (id) => {
+  return useQuery({
+    queryKey: ['toilet', id],
+    queryFn: () => getToiletById(id),
+    enabled: !!id,
+  });
+};
+
+// 내가 등록한 화장실 목록 조회 훅
 export const useMyToilets = () => {
   return useQuery({
     queryKey: ['myToilets'],
     queryFn: getMyToilets,
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
   });
 };
 
-// 화장실 상세 조회
-export const useToiletDetail = (toiletId) => {
-  return useQuery({
-    queryKey: ['toilet', toiletId],
-    queryFn: () => getToiletById(toiletId),
-    enabled: !!toiletId,
-  });
-};
-
-// 화장실 등록
-export const useCreateToilet = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: createToilet,
-    onSuccess: () => {
-      queryClient.invalidateQueries(['myToilets']);
-    },
-  });
-};
-
-// 화장실 수정 (기존)
+// 수정
 export const useUpdateToilet = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: updateToilet,
+    mutationFn: ({ id, toiletData }) => updateToilet({ id, toiletData }),
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries(['toilet', id]);
       queryClient.invalidateQueries(['myToilets']);
@@ -53,47 +39,34 @@ export const useUpdateToilet = () => {
 };
 
 // 이미지 업로드
-export const useUploadImages = (toiletId) => {
-  const queryClient = useQueryClient();
+export const useUploadToiletImages = () => {
   return useMutation({
-    mutationFn: (files) => uploadToiletImages(toiletId, files),
-    onSuccess: () => {
-      queryClient.invalidateQueries(['toilet', toiletId]);
+    mutationFn: (imageData) => uploadToiletImages(imageData),
+    onSuccess: (data) => {
+      console.log('✅ 이미지 업로드 성공:', data);
     },
   });
 };
 
 // 이미지 단건 삭제
-export const useDeleteImage = (toiletId) => {
+export const useDeleteToiletImage = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (imageId) => deleteToiletImage(toiletId, imageId),
-    onSuccess: () => {
+    mutationFn: ({ toiletId, imageId }) =>
+      deleteToiletImage({ toiletId, imageId }),
+    onSuccess: (_, { toiletId }) => {
       queryClient.invalidateQueries(['toilet', toiletId]);
     },
   });
 };
 
 // 이미지 전체 삭제
-export const useDeleteAllImages = (toiletId) => {
+export const useDeleteAllToiletImages = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => deleteAllToiletImages(toiletId),
-    onSuccess: () => {
+    mutationFn: ({ toiletId }) => deleteAllToiletImages({ toiletId }),
+    onSuccess: (_, { toiletId }) => {
       queryClient.invalidateQueries(['toilet', toiletId]);
-    },
-  });
-};
-
-// 화장실 수정 (imageIds 포함)
-export const useUpdateToiletWithImages = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, toiletData, imageIds }) =>
-      updateToiletWithImages({ id, toiletData, imageIds }),
-    onSuccess: (_, { id }) => {
-      queryClient.invalidateQueries(['toilet', id]);
-      queryClient.invalidateQueries(['myToilets']);
     },
   });
 };

--- a/src/hooks/mypage/useToiletApi.js
+++ b/src/hooks/mypage/useToiletApi.js
@@ -1,11 +1,99 @@
-import { useQuery } from '@tanstack/react-query';
-import { getMyToilets } from '@/apis/mypage/toiletApi';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getMyToilets,
+  getToiletById,
+  createToilet,
+  updateToilet,
+  uploadToiletImages,
+  deleteToiletImage,
+  deleteAllToiletImages,
+  updateToiletWithImages,
+} from '@/apis/mypage/toiletApi';
 
+// 내가 등록한 화장실 목록 조회
 export const useMyToilets = () => {
   return useQuery({
     queryKey: ['myToilets'],
     queryFn: getMyToilets,
-    staleTime: 5 * 60 * 1000, // 5분
-    cacheTime: 10 * 60 * 1000, // 10분
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+  });
+};
+
+// 화장실 상세 조회
+export const useToiletDetail = (toiletId) => {
+  return useQuery({
+    queryKey: ['toilet', toiletId],
+    queryFn: () => getToiletById(toiletId),
+    enabled: !!toiletId,
+  });
+};
+
+// 화장실 등록
+export const useCreateToilet = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createToilet,
+    onSuccess: () => {
+      queryClient.invalidateQueries(['myToilets']);
+    },
+  });
+};
+
+// 화장실 수정 (기존)
+export const useUpdateToilet = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateToilet,
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries(['toilet', id]);
+      queryClient.invalidateQueries(['myToilets']);
+    },
+  });
+};
+
+// 이미지 업로드
+export const useUploadImages = (toiletId) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (files) => uploadToiletImages(toiletId, files),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['toilet', toiletId]);
+    },
+  });
+};
+
+// 이미지 단건 삭제
+export const useDeleteImage = (toiletId) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (imageId) => deleteToiletImage(toiletId, imageId),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['toilet', toiletId]);
+    },
+  });
+};
+
+// 이미지 전체 삭제
+export const useDeleteAllImages = (toiletId) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteAllToiletImages(toiletId),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['toilet', toiletId]);
+    },
+  });
+};
+
+// 화장실 수정 (imageIds 포함)
+export const useUpdateToiletWithImages = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, toiletData, imageIds }) =>
+      updateToiletWithImages({ id, toiletData, imageIds }),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries(['toilet', id]);
+      queryClient.invalidateQueries(['myToilets']);
+    },
   });
 };

--- a/src/hooks/useRegisterToilet.js
+++ b/src/hooks/useRegisterToilet.js
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useCreateToilet, useUploadToiletImages } from '@/hooks/register/useRegisterApi';
+import {
+  useCreateToilet,
+  useUploadToiletImages,
+} from '@/hooks/register/useRegisterApi';
 
 export const useRegisterToilet = () => {
   const navigate = useNavigate();
@@ -18,51 +21,59 @@ export const useRegisterToilet = () => {
       startHour: '09',
       startMinute: '00',
       endHour: '18',
-      endMinute: '00'
+      endMinute: '00',
     },
     facilities: [],
-    specialFacilities: []
+    specialFacilities: [],
   });
 
   const { mutateAsync: createToilet, isPending: creating } = useCreateToilet();
-  const { mutateAsync: uploadImages, isPending: uploading } = useUploadToiletImages();
+  const { mutateAsync: uploadImages, isPending: uploading } =
+    useUploadToiletImages();
 
   const handleInputChange = (key, value) => {
-    setFormData(prev => ({ ...prev, [key]: value }));
+    setFormData((prev) => ({ ...prev, [key]: value }));
   };
 
   const handleArrayToggle = (key, value) => {
-    setFormData(prev => {
+    setFormData((prev) => {
       const arr = new Set(prev[key] || []);
-      if (arr.has(value)) arr.delete(value); else arr.add(value);
+      if (arr.has(value)) arr.delete(value);
+      else arr.add(value);
       return { ...prev, [key]: Array.from(arr) };
     });
   };
 
   const handleTimeChange = (timeType, value) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
-      operatingHours: { ...prev.operatingHours, [timeType]: value }
+      operatingHours: { ...prev.operatingHours, [timeType]: value },
     }));
   };
 
   const handleImageUpload = (event) => {
     const files = Array.from(event.target.files || []);
-    const newImages = files.map(file => ({
-        file,
-        url: URL.createObjectURL(file),
-        id: `${file.name}-${file.lastModified}`
+    const newImages = files.map((file) => ({
+      file,
+      url: URL.createObjectURL(file),
+      id: `${file.name}-${file.lastModified}`,
     }));
-    setFormData(prev => ({ ...prev, images: [...prev.images, ...newImages] }));
+    setFormData((prev) => ({
+      ...prev,
+      images: [...prev.images, ...newImages],
+    }));
   };
 
   const handleImageRemove = (imageId) => {
-    setFormData(prev => {
-        const imageToRemove = prev.images.find(image => image.id === imageId);
-        if (imageToRemove) {
-            URL.revokeObjectURL(imageToRemove.url);
-        }
-        return { ...prev, images: prev.images.filter(image => image.id !== imageId) };
+    setFormData((prev) => {
+      const imageToRemove = prev.images.find((image) => image.id === imageId);
+      if (imageToRemove) {
+        URL.revokeObjectURL(imageToRemove.url);
+      }
+      return {
+        ...prev,
+        images: prev.images.filter((image) => image.id !== imageId),
+      };
     });
   };
 
@@ -104,7 +115,7 @@ export const useRegisterToilet = () => {
       if (newId && formData.images?.length > 0) {
         const fd = new FormData();
         // ✨ 수정된 부분: API 명세에 맞게 'images'를 'files'로 변경
-        formData.images.forEach(image => fd.append('files', image.file));
+        formData.images.forEach((image) => fd.append('files', image.file));
         await uploadImages({ toiletId: newId, imageData: fd });
       }
 
@@ -116,13 +127,15 @@ export const useRegisterToilet = () => {
       }
     } catch (e) {
       console.error(e);
-      const errorMessage = e.response?.data?.message || '등록 중 오류가 발생했습니다.';
+      const errorMessage =
+        e.response?.data?.message || '등록 중 오류가 발생했습니다.';
       alert(errorMessage);
     }
   };
 
   return {
     formData,
+    setFormData,
     handleInputChange,
     handleArrayToggle,
     handleTimeChange,

--- a/src/pages/mypage/EditToilet.jsx
+++ b/src/pages/mypage/EditToilet.jsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import Pencil from '@/assets/svg/toiletDetail/pencil.svg?react';
 import { useRegisterToilet } from '@/hooks/useRegisterToilet';
 import { useDropdown } from '@/hooks/useDropdown';
@@ -7,42 +9,131 @@ import OperatingHours from '@/components/register/OperatingHours';
 import FacilityTags from '@/components/register/FacilityTags';
 import DescriptionForm from '@/components/register/DescriptionForm';
 import ImageUpload from '@/components/register/ImageUpload';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getToiletById, updateToilet } from '@/apis/mypage/toiletApi';
+import { facilities, specialFacilities } from '@/constants/facilityData';
 
-const RegisterToilet = () => {
+const EditToilet = () => {
+  const { toiletId } = useParams();
+  const queryClient = useQueryClient();
+
   const {
     formData,
+    setFormData,
     handleInputChange,
     handleArrayToggle,
-    handleTimeChange,
     handleImageUpload,
     handleImageRemove,
-    handleSubmit,
     busy,
   } = useRegisterToilet();
 
   const { dropdownOpen, dropdownRef, toggleDropdown, closeAllDropdowns } =
     useDropdown();
 
+  // 상세 조회
+  const { data } = useQuery({
+    queryKey: ['toilet', toiletId],
+    queryFn: () => getToiletById(toiletId),
+    enabled: !!toiletId,
+  });
+
+  // 수정 mutation
+  const mutation = useMutation({
+    mutationFn: ({ id, toiletData }) => updateToilet({ id, toiletData }),
+    onSuccess: () => {
+      alert('화장실 정보가 수정되었습니다.');
+      queryClient.invalidateQueries(['toilet', toiletId]);
+      queryClient.invalidateQueries(['myToilets']);
+    },
+    onError: (err) => {
+      console.error('❌ 수정 실패:', err);
+      alert('수정 실패');
+    },
+  });
+
+  // 상세조회 데이터 -> formData 세팅
+  useEffect(() => {
+    if (data?.data) {
+      const toilet = data.data;
+
+      // tags 분리
+      const selectedFacilities = (toilet.tags || []).filter((tag) =>
+        facilities.includes(tag)
+      );
+      const selectedSpecial = (toilet.tags || []).filter((tag) =>
+        specialFacilities.includes(tag)
+      );
+
+      setFormData({
+        name: toilet.name || '',
+        type: toilet.type === 'PUBLIC' ? 'public' : 'private',
+        address: toilet.location?.address || '',
+        detailAddress: toilet.location?.detailAddress || '',
+        floor: toilet.location?.floor || '',
+        operatingHours: {
+          startHour: toilet.hours?.openTime?.split(':')[0] || '',
+          startMinute: toilet.hours?.openTime?.split(':')[1] || '',
+          endHour: toilet.hours?.closeTime?.split(':')[0] || '',
+          endMinute: toilet.hours?.closeTime?.split(':')[1] || '',
+        },
+        isOpen24h: toilet.hours?.isOpen24h || false,
+        facilities: selectedFacilities,
+        specialFacilities: selectedSpecial,
+        description: toilet.description || '',
+        specialNotes: toilet.particulars || '',
+        images: (toilet.images || []).map((url, idx) => ({ id: idx, url })),
+      });
+    }
+  }, [data, setFormData]);
+
   const onTimeChange = (timeType, value) => {
-    const timeValue = {
-      ...formData.operatingHours,
-      [timeType]: value,
-    };
-    handleInputChange('operatingHours', timeValue);
+    setFormData((prev) => ({
+      ...prev,
+      operatingHours: {
+        ...prev.operatingHours,
+        [timeType]: value,
+      },
+    }));
     closeAllDropdowns();
+  };
+
+  const handleSave = () => {
+    const payload = {
+      name: formData.name,
+      type: formData.type === 'public' ? 'PUBLIC' : 'PRIVATE',
+      address: formData.address,
+      floor: Number(formData.floor) || 0,
+      openTime: `${formData.operatingHours.startHour || '00'}:${
+        formData.operatingHours.startMinute || '00'
+      }:00`,
+      closeTime: `${formData.operatingHours.endHour || '00'}:${
+        formData.operatingHours.endMinute || '00'
+      }:00`,
+      isOpen24h: formData.isOpen24h,
+      tags: [
+        ...(formData.facilities || []),
+        ...(formData.specialFacilities || []),
+      ],
+      description: formData.description,
+      particulars: formData.specialNotes,
+    };
+
+    console.log('🚀 수정 요청 payload:', payload);
+
+    mutation.mutate({ id: toiletId, toiletData: payload });
   };
 
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-[1440px] mx-auto px-4 lg:px-[125px] py-8 lg:py-[65px]">
         <h1 className="text-heading1 text-gray-10 mb-8 lg:mb-16">
-          화장실 등록
+          화장실 정보 수정
         </h1>
 
         <div className="flex flex-col lg:flex-row gap-12 min-w-full lg:min-w-[1200px]">
           {/* 왼쪽 폼 */}
           <div className="w-full lg:w-[400px] flex flex-col gap-8 flex-shrink-0">
-            {/* ✨ 화장실 이름 입력 필드 추가 ✨ */}
+            {/* 화장실 이름 입력 */}
             <div className="flex flex-col items-start gap-2 p-10 self-stretch rounded-[10px] border border-gray-2 bg-white">
               <div className="text-body1 text-gray-10 mb-4">화장실 이름</div>
               <input
@@ -94,16 +185,16 @@ const RegisterToilet = () => {
 
             <ImageUpload onImageUpload={handleImageUpload} />
 
-            {/* 등록 버튼 */}
+            {/* 수정 버튼 */}
             <div className="flex justify-end mt-4">
               <button
-                onClick={handleSubmit}
+                onClick={handleSave}
                 disabled={busy}
                 className="flex items-center gap-2 px-8 lg:px-24 py-6 lg:py-9 bg-main hover:bg-main-2 rounded-[10px] transition-colors disabled:opacity-50"
               >
                 <Pencil className="w-6 h-6 text-white flex-shrink-0" />
                 <span className="text-heading3-bold text-white whitespace-nowrap">
-                  {busy ? '등록 중...' : '화장실 정보 등록'}
+                  {busy ? '수정 중...' : '화장실 정보 수정'}
                 </span>
               </button>
             </div>
@@ -114,4 +205,4 @@ const RegisterToilet = () => {
   );
 };
 
-export default RegisterToilet;
+export default EditToilet;

--- a/src/pages/mypage/EditToilet.jsx
+++ b/src/pages/mypage/EditToilet.jsx
@@ -56,7 +56,6 @@ const EditToilet = () => {
     if (data?.data) {
       const toilet = data.data;
 
-      // tags 분리
       const selectedFacilities = (toilet.tags || []).filter((tag) =>
         facilities.includes(tag)
       );
@@ -68,8 +67,7 @@ const EditToilet = () => {
         name: toilet.name || '',
         type: toilet.type === 'PUBLIC' ? 'public' : 'private',
         address: toilet.location?.address || '',
-        detailAddress: toilet.location?.detailAddress || '',
-        floor: toilet.location?.floor || '',
+        floor: toilet.location?.floor?.toString() || '', // 🔥 floor 반영
         operatingHours: {
           startHour: toilet.hours?.openTime?.split(':')[0] || '',
           startMinute: toilet.hours?.openTime?.split(':')[1] || '',
@@ -102,7 +100,7 @@ const EditToilet = () => {
       name: formData.name,
       type: formData.type === 'public' ? 'PUBLIC' : 'PRIVATE',
       address: formData.address,
-      floor: Number(formData.floor) || 0,
+      floor: formData.floor ? Number(formData.floor) : null, // 🔥 floor 전송
       openTime: `${formData.operatingHours.startHour || '00'}:${
         formData.operatingHours.startMinute || '00'
       }:00`,
@@ -125,15 +123,14 @@ const EditToilet = () => {
 
   return (
     <div className="min-h-screen bg-white">
-      <div className="max-w-[1440px] mx-auto px-4 lg:px-[125px] py-8 lg:py-[65px]">
-        <h1 className="text-heading1 text-gray-10 mb-8 lg:mb-16">
+      <div className="max-w-[1200px] mx-auto px-4 lg:px-[60px] py-8 lg:py-[40px]">
+        <h1 className="text-heading1 text-gray-10 mb-8 lg:mb-12">
           화장실 정보 수정
         </h1>
 
-        <div className="flex flex-col lg:flex-row gap-12 min-w-full lg:min-w-[1200px]">
+        <div className="flex flex-col lg:flex-row gap-8 w-full">
           {/* 왼쪽 폼 */}
           <div className="w-full lg:w-[400px] flex flex-col gap-8 flex-shrink-0">
-            {/* 화장실 이름 입력 */}
             <div className="flex flex-col items-start gap-2 p-10 self-stretch rounded-[10px] border border-gray-2 bg-white">
               <div className="text-body1 text-gray-10 mb-4">화장실 이름</div>
               <input
@@ -165,11 +162,6 @@ const EditToilet = () => {
             />
           </div>
 
-          {/* 세로 분할선 */}
-          <div className="hidden lg:flex items-center">
-            <div className="w-px h-full lg:h-[1180px] bg-gray-1"></div>
-          </div>
-
           {/* 오른쪽 콘텐츠 */}
           <div className="flex-1 flex flex-col gap-8">
             <FacilityTags
@@ -185,7 +177,6 @@ const EditToilet = () => {
 
             <ImageUpload onImageUpload={handleImageUpload} />
 
-            {/* 수정 버튼 */}
             <div className="flex justify-end mt-4">
               <button
                 onClick={handleSave}

--- a/src/pages/mypage/EditToilet.jsx
+++ b/src/pages/mypage/EditToilet.jsx
@@ -11,6 +11,7 @@ import DescriptionForm from '@/components/register/DescriptionForm';
 import ImageUpload from '@/components/register/ImageUpload';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getToiletById, updateToilet } from '@/apis/mypage/toiletApi';
+import { useUploadToiletImages } from '@/hooks/mypage/useToiletApi';
 import { facilities, specialFacilities } from '@/constants/facilityData';
 
 const EditToilet = () => {
@@ -22,7 +23,6 @@ const EditToilet = () => {
     setFormData,
     handleInputChange,
     handleArrayToggle,
-    handleImageUpload,
     handleImageRemove,
     busy,
   } = useRegisterToilet();
@@ -51,6 +51,9 @@ const EditToilet = () => {
     },
   });
 
+  // 이미지 업로드 mutation
+  const uploadMutation = useUploadToiletImages();
+
   // 상세조회 데이터 -> formData 세팅
   useEffect(() => {
     if (data?.data) {
@@ -67,7 +70,7 @@ const EditToilet = () => {
         name: toilet.name || '',
         type: toilet.type === 'PUBLIC' ? 'public' : 'private',
         address: toilet.location?.address || '',
-        floor: toilet.location?.floor?.toString() || '', // 🔥 floor 반영
+        floor: toilet.location?.floor?.toString() || '',
         operatingHours: {
           startHour: toilet.hours?.openTime?.split(':')[0] || '',
           startMinute: toilet.hours?.openTime?.split(':')[1] || '',
@@ -100,7 +103,7 @@ const EditToilet = () => {
       name: formData.name,
       type: formData.type === 'public' ? 'PUBLIC' : 'PRIVATE',
       address: formData.address,
-      floor: formData.floor ? Number(formData.floor) : null, // 🔥 floor 전송
+      floor: formData.floor ? Number(formData.floor) : null,
       openTime: `${formData.operatingHours.startHour || '00'}:${
         formData.operatingHours.startMinute || '00'
       }:00`,
@@ -119,6 +122,19 @@ const EditToilet = () => {
     console.log('🚀 수정 요청 payload:', payload);
 
     mutation.mutate({ id: toiletId, toiletData: payload });
+  };
+
+  // 이미지 업로드 핸들러
+  const handleImageUpload = (event) => {
+    const files = event.target.files;
+    if (!files || files.length === 0) return;
+
+    const formData = new FormData();
+    for (let file of files) {
+      formData.append('files', file);
+    }
+
+    uploadMutation.mutate(formData);
   };
 
   return (

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -8,7 +8,7 @@ const MyPage = () => {
         <div className="flex gap-[54px]">
           {/* 사이드바 */}
           <Sidebar />
-          
+
           {/* 메인 콘텐츠 영역 */}
           <div className="flex-1">
             <Outlet />

--- a/src/pages/mypage/ToiletManagement.jsx
+++ b/src/pages/mypage/ToiletManagement.jsx
@@ -1,18 +1,13 @@
-import { useState } from 'react';
-import { mockMyToilets as initialToilets } from '@/mocks/mockMyToilets';
 import ToiletCard from '@/components/mypage/ToiletCard';
+import { useMyToilets } from '@/hooks/mypage/useToiletApi';
 
 const ToiletManagement = () => {
-  const [toilets, setToilets] = useState(initialToilets);
+  const { data, isLoading, isError } = useMyToilets();
 
-  // 저장 시 리스트 업데이트
-  const handleSave = (id, updatedData) => {
-    setToilets((prev) =>
-      prev.map((toilet) =>
-        toilet.id === id ? { ...toilet, ...updatedData } : toilet
-      )
-    );
-  };
+  if (isLoading) return <p>내 화장실 불러오는 중...</p>;
+  if (isError) return <p>내 화장실 불러오기 실패</p>;
+
+  const toilets = data?.data?.toilets || [];
 
   return (
     <div className="w-full">
@@ -21,9 +16,20 @@ const ToiletManagement = () => {
       </h2>
 
       <div className="divide-y divide-gray-2 border-t border-b border-gray-2">
-        {toilets.map((toilet) => (
-          <ToiletCard key={toilet.id} toilet={toilet} onSave={handleSave} />
-        ))}
+        {toilets.length > 0 ? (
+          toilets.map((toilet) => (
+            <ToiletCard key={toilet.id} toilet={toilet} onSave={() => {}} />
+          ))
+        ) : (
+          <div className="flex flex-col items-center justify-center py-20">
+            <p className="text-heading3-regular text-gray-5 mb-4">
+              등록한 화장실이 없습니다.
+            </p>
+            <p className="text-body1 text-gray-5">
+              첫 번째 화장실을 등록해보세요!
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/registerToilet/RegisterToilet.jsx
+++ b/src/pages/registerToilet/RegisterToilet.jsx
@@ -42,7 +42,7 @@ const RegisterToilet = () => {
         <div className="flex flex-col lg:flex-row gap-12 min-w-full lg:min-w-[1200px]">
           {/* 왼쪽 폼 */}
           <div className="w-full lg:w-[400px] flex flex-col gap-8 flex-shrink-0">
-            {/* ✨ 화장실 이름 입력 필드 추가 ✨ */}
+            {/* 화장실 이름 입력 */}
             <div className="flex flex-col items-start gap-2 p-10 self-stretch rounded-[10px] border border-gray-2 bg-white">
               <div className="text-body1 text-gray-10 mb-4">화장실 이름</div>
               <input
@@ -54,16 +54,19 @@ const RegisterToilet = () => {
               />
             </div>
 
+            {/* 주소 + 층수 */}
             <AddressForm
               formData={formData}
               onInputChange={handleInputChange}
             />
 
+            {/* 공중/개인 선택 */}
             <TypeSelector
               formData={formData}
               onInputChange={handleInputChange}
             />
 
+            {/* 운영 시간 */}
             <OperatingHours
               formData={formData}
               onTimeChange={onTimeChange}


### PR DESCRIPTION
### 💡 To Reviewers

등록한 화장실 관리 API 구현

---

### 🔥 작업 내용

- src/apis/mypage/toiletApi.js : 내가 등록한 화장실 목록 조회 API 함수 생성
- src/hooks/mypage/useToiletApi.js : useMyToilets React Query 훅 생성
- src/pages/mypage/ToiletManagement.jsx : mock 데이터 제거, API 기반으로 목록 조회하도록 수정

---

### 🤔 추후 작업 예정

- 등록한 화장실 수정하는 기능은 우선 화장실 등록 API 연결 되고 나서 구현 예정입니다!

---

### 📸 작업 결과 (선택)

- 작업 결과를 보여주는 스크린샷이 있다면 첨부해주세요.

---

### 🔗 관련 이슈 (선택)

- 연결된 이슈 번호가 있다면 '#번호' 형식으로 작성해주세요.
